### PR TITLE
fix "error in running command" during conda installation

### DIFF
--- a/R/installConda.R
+++ b/R/installConda.R
@@ -133,7 +133,7 @@ installConda <- function(installed=TRUE) {
         conda.exists <- file.exists(file.path(dest_path, "condabin/conda.bat"))
     }
 
-    python.cmd <- getPythonBinary(dest_path)
+    python.cmd <- path.expand(getPythonBinary(dest_path))
     report <- system2(python.cmd, c("-E", "-c", shQuote("print(1)")), stdout=TRUE, stderr=FALSE)
     if (!conda.exists || report!="1") {
         stop("conda installation failed for an unknown reason")


### PR DESCRIPTION
On my (organization's) machine using `basilisk` failed with:
`Error in system2(python.cmd, c("-E", "-c", shQuote("print(1)")), stdout = TRUE,  : error in running command`
(The error message comes from `sh` and is due to `~` in `python.cm` not being expanded). Using expand.path fixed it for me (for `RELEASE_3_12`) I think. (can't tests for master since I am stuck with R/4.0 atm)