### PR TITLE
Add 'full.activation' argument to activateEnvironment().

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: basilisk.utils
-Version: 1.15.0
-Date: 2023-09-03
+Version: 1.15.1
+Date: 2023-11-15
 Title: Basilisk Installation Utilities
 Authors@R: c(person("Aaron", "Lun", role=c("aut", "cre", "cph"),
         email="infinite.monkeys.with.keyboards@gmail.com"))

--- a/R/activateEnvironment.R
+++ b/R/activateEnvironment.R
@@ -13,12 +13,9 @@
 #' typically the output of \code{activateEnvironment}.
 #'
 #' @details
-#' Conda environments generally need to be activated with the
-#' \code{conda activate} command to function properly.
+#' Conda environments generally need to be activated with the \code{conda activate} command to function properly.
 #' This is especially relevant on Windows where the \code{"PATH"} variable needs to be modified for the DLL search.
-#' When performing full activation, the \code{activateEnvironment} function
-#' mimics the effect of the \code{conda activate} command by modifying
-#' environment variables in the current R session.
+#' When performing full activation, the \code{activateEnvironment} function mimics the effect \code{conda activate} by modifying environment variables in the current R session.
 #' This can be reversed by \code{deactivateEnvironment} once the Conda environment is no longer in use.
 #'
 #' The \code{activateEnvironment} function will also unset a few bothersome environment variables:
@@ -48,8 +45,7 @@
 #' @export
 #' @author Aaron Lun
 activateEnvironment <- function(envpath=NULL, full.activation=NA, loc=getCondaDir()) {
-    full.activation <- isTRUE(full.activation) ||
-                       (isWindows() && !isFALSE(full.activation))
+    full.activation <- isTRUE(full.activation) || (isWindows() && !isFALSE(full.activation))
 
     ADD <- function(listing, var) {
         previous <- Sys.getenv(var, unset=NA)
@@ -76,8 +72,8 @@ activateEnvironment <- function(envpath=NULL, full.activation=NA, loc=getCondaDi
     output <- ADD(output, "PYTHONNOUSERSITE")
     Sys.setenv(PYTHONNOUSERSITE=1)
 
+    # Activating the conda environment, if requested.
     if (full.activation) {
-        # Activating the conda environment.
         output <- .activate_condaenv(output, envpath, loc)
     }
 

--- a/man/activateEnvironment.Rd
+++ b/man/activateEnvironment.Rd
@@ -35,12 +35,9 @@ It returns \code{NULL} invisibly.
 Mimic the (de)activation of a Conda environment by modifying environment variables in the current R process.
 }
 \details{
-Conda environments generally need to be activated with the
-\code{conda activate} command to function properly.
+Conda environments generally need to be activated with the \code{conda activate} command to function properly.
 This is especially relevant on Windows where the \code{"PATH"} variable needs to be modified for the DLL search.
-When performing full activation, the \code{activateEnvironment} function
-mimics the effect of the \code{conda activate} command by modifying
-environment variables in the current R session.
+When performing full activation, the \code{activateEnvironment} function mimics the effect \code{conda activate} by modifying environment variables in the current R session.
 This can be reversed by \code{deactivateEnvironment} once the Conda environment is no longer in use.
 
 The \code{activateEnvironment} function will also unset a few bothersome environment variables:

--- a/man/activateEnvironment.Rd
+++ b/man/activateEnvironment.Rd
@@ -5,13 +5,18 @@
 \alias{deactivateEnvironment}
 \title{Activate a Conda environment}
 \usage{
-activateEnvironment(envpath = NULL, loc = getCondaDir())
+activateEnvironment(envpath = NULL, full.activation = NA, loc = getCondaDir())
 
 deactivateEnvironment(listing)
 }
 \arguments{
 \item{envpath}{String containing the path to the Conda environment to activate.
 If \code{NULL}, the base Conda instance at \code{\link{getCondaDir}()} is activated.}
+
+\item{full.activation}{Logical scalar indicating whether the
+\code{conda activate} command should be run on the environment.
+Default is \code{NA}, which means \code{TRUE} on Windows and \code{FALSE}
+anywhere else.}
 
 \item{loc}{String containing the path to the root of a conda instance.}
 
@@ -30,13 +35,15 @@ It returns \code{NULL} invisibly.
 Mimic the (de)activation of a Conda environment by modifying environment variables in the current R process.
 }
 \details{
-Conda environments generally need to be activated to function properly.
+Conda environments generally need to be activated with the
+\code{conda activate} command to function properly.
 This is especially relevant on Windows where the \code{"PATH"} variable needs to be modified for the DLL search.
-The \code{.activateEnvironment} function mimics the effect of activation
-by modifying environment variables in the current R session.
-This can be reversed by \code{.deactivateEnvironment} once the Conda environment is no longer in use.
+When performing full activation, the \code{activateEnvironment} function
+mimics the effect of the \code{conda activate} command by modifying
+environment variables in the current R session.
+This can be reversed by \code{deactivateEnvironment} once the Conda environment is no longer in use.
 
-The \code{.activateEnvironment} function will also unset a few bothersome environment variables:
+The \code{activateEnvironment} function will also unset a few bothersome environment variables:
 \itemize{
 \item \code{"PYTHONPATH"}: to avoid compromising the version guarantees 
 if \pkg{reticulate}'s \code{import} is allowed to search other locations beyond the specified Conda environment.


### PR DESCRIPTION
I hesitated between `run.conda.activate` and `full.activation` for the name of this argument. Finally went for the latter. Let me know if you think of a better name.

About the default value for this argument: I went for `NA`, which means `TRUE` on Windows and `FALSE` anywhere else. My understanding of the situation is that it's important to do it on Windows or bad things are almost certainly going to happen there. Let me know if you think we should use a different default.

Thanks!