### PR TITLE
change the default version of miniconda to be used

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: basilisk.utils
-Version: 1.15.1
+Version: 1.15.1002
 Date: 2023-11-15
 Title: Basilisk Installation Utilities
 Authors@R: c(person("Aaron", "Lun", role=c("aut", "cre", "cph"),

--- a/R/installConda.R
+++ b/R/installConda.R
@@ -104,7 +104,7 @@ installConda <- function(installed=TRUE) {
         }
     }, add=TRUE, after=FALSE)
 
-    version <- Sys.getenv("BASILISK_MINICONDA_VERSION", "py39_4.12.0")
+    version <- Sys.getenv("BASILISK_MINICONDA_VERSION", "py311_23.11.0-2") # VJC 1/16/2024
     base_url <- "https://repo.anaconda.com/miniconda"
 
     if (isWindows()) {


### PR DESCRIPTION
This simply alters the miniconda spec to the latest version available for linux.

